### PR TITLE
Rebuild for latest airflow

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: b1f29280f8e917cce7f8898ff7c5fdc673f9ec394f4ba9abfb23be1226e07727
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -25,10 +25,7 @@ requirements:
     - python >=3.6
     - apache-airflow >=2.1.0
     - snowflake-connector-python >=2.4.1
-    # temporary workaround to deal with the incorrect contraints in
-    # https://github.com/conda-forge/snowflake-sqlalchemy-feedstock/pull/7
-    - snowflake-sqlalchemy >=1.1.0,<1.3.1
-    #- snowflake-sqlalchemy >=1.1.0
+    - snowflake-sqlalchemy >=1.1.0
 
 test:
   imports:


### PR DESCRIPTION
More relaxed constraints on sqlalchemy in airflow 2.1.3 should
allow us to relax the upper bound on snowflake-sqlalchemy.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
